### PR TITLE
Fix logcat format

### DIFF
--- a/LogCatWindow.cs
+++ b/LogCatWindow.cs
@@ -67,7 +67,10 @@ public class LogCatWindow : EditorWindow
              || filterOnlyVerbose && log.Type == 'V')).ToList();
         }
 
-        Repaint();
+        if (logCatProcess != null)
+        {
+            Repaint();
+        }
     }
     
     void OnGUI()

--- a/LogCatWindow.cs
+++ b/LogCatWindow.cs
@@ -31,6 +31,7 @@ public class LogCatWindow : EditorWindow
     private List<LogCatLog> logsList = new List<LogCatLog>();
     private List<LogCatLog> filteredList = new List<LogCatLog>(memoryLimit);
     private const string LogcatPattern = @"([0-1][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9]\.[0-9]{3}) ([WIEDV])/(.*)";
+    private static readonly Regex LogcatRegex = new Regex(LogcatPattern, RegexOptions.Compiled);
     
     // Filtered GUI list scroll position
     private Vector2 scrollPosition = new Vector2(0, 0);
@@ -213,7 +214,7 @@ public class LogCatWindow : EditorWindow
             // D - debug
             // I - info
             // V - verbose
-            Match match = Regex.Match(data, LogcatPattern);
+            Match match = LogcatRegex.Match(data);
             if (match.Success)
             {
                 Type = match.Groups[2].Value[0];

--- a/LogCatWindow.cs
+++ b/LogCatWindow.cs
@@ -57,6 +57,8 @@ public class LogCatWindow : EditorWindow
              || filterOnlyInfo && log.Type == 'I' 
              || filterOnlyVerbose && log.Type == 'V')).ToList();
         }
+        
+        Repaint();
     }
     
     void OnGUI()
@@ -90,7 +92,7 @@ public class LogCatWindow : EditorWindow
             logProcessInfo.WindowStyle = ProcessWindowStyle.Hidden;
             
             // Add additional -s argument for filtering by Unity tag.
-            logProcessInfo.Arguments = "logcat"+(prefilterOnlyUnity ? " -s  \"Unity\"": "");
+            logProcessInfo.Arguments = "logcat -v brief"+(prefilterOnlyUnity ? " -s  \"Unity\"": "");
             
             logCatProcess = Process.Start(logProcessInfo);  
             

--- a/LogCatWindow.cs
+++ b/LogCatWindow.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 using System;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.IO;
 #if UNITY_2017_3_OR_NEWER
@@ -102,6 +103,7 @@ public class LogCatWindow : EditorWindow
             logProcessInfo.UseShellExecute = false;
             logProcessInfo.RedirectStandardOutput = true;
             logProcessInfo.RedirectStandardError = true;
+            logProcessInfo.StandardOutputEncoding = Encoding.UTF8;
             logProcessInfo.FileName = adbPath;
             logProcessInfo.WindowStyle = ProcessWindowStyle.Hidden;
             

--- a/LogCatWindow.cs
+++ b/LogCatWindow.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 using System;
+using System.Text.RegularExpressions;
 
 public class LogCatWindow : EditorWindow
 {
@@ -29,6 +30,7 @@ public class LogCatWindow : EditorWindow
     // Log entries
     private List<LogCatLog> logsList = new List<LogCatLog>();
     private List<LogCatLog> filteredList = new List<LogCatLog>(memoryLimit);
+    private const string LogcatPattern = @"([0-1][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9]\.[0-9]{3}) ([WIEDV])/(.*)";
     
     // Filtered GUI list scroll position
     private Vector2 scrollPosition = new Vector2(0, 0);
@@ -92,7 +94,7 @@ public class LogCatWindow : EditorWindow
             logProcessInfo.WindowStyle = ProcessWindowStyle.Hidden;
             
             // Add additional -s argument for filtering by Unity tag.
-            logProcessInfo.Arguments = "logcat -v brief"+(prefilterOnlyUnity ? " -s  \"Unity\"": "");
+            logProcessInfo.Arguments = "logcat -v time"+(prefilterOnlyUnity ? " -s  \"Unity\"": "");
             
             logCatProcess = Process.Start(logProcessInfo);  
             
@@ -211,10 +213,21 @@ public class LogCatWindow : EditorWindow
             // D - debug
             // I - info
             // V - verbose
-            Type = data[0];
-            
-            Message = data.Substring(2);
-            CreationDate = DateTime.Now.ToString("H:mm:ss");
+            Match match = Regex.Match(data, LogcatPattern);
+            if (match.Success)
+            {
+                Type = match.Groups[2].Value[0];
+
+                Message = match.Groups[3].Value;
+                CreationDate = match.Groups[1].Value;
+            }
+            else
+            {
+                Type = 'V';
+
+                Message = data;
+                CreationDate = DateTime.Now.ToString("MM-dd HH:mm:ss.fff");
+            }
         }
         
         public string CreationDate


### PR DESCRIPTION
The default format for logcat has been changed from `brief` to `threadtime`. Therefore, log messages are not color-coded by priority.
Also, the head of the log message is not the log time but the PC time.
<https://android.googlesource.com/platform/system/core/+/649fc605f8094c06a38251466ccb15a722e8a91f%5E%21/logcat/logcat.cpp>

Therefore, we specified the log format to output the time and corrected the message analysis.
And redraw the log for immediate display.
